### PR TITLE
Do not use the top level links and meta fields in relationships field

### DIFF
--- a/lib/util/serialize-resource.js
+++ b/lib/util/serialize-resource.js
@@ -207,6 +207,11 @@ module.exports = function serializeResource(payload, data, options, cb) {
                         }
                     ], _fn);
 
+                    if (options.minimizePayload === true) {
+                        // Remove empty fields
+                        resource.relationships[relationshipName] = _.omitBy(resource.relationships[relationshipName], (property) => _.isObject(property) && _.isEmpty(property));
+                    }
+
                 });
             }, fn);
         }],


### PR DESCRIPTION
Top level meta and links fields were being set in the relationships field.
